### PR TITLE
BGDIINF_SB-2172: Disable STAC version migration

### DIFF
--- a/src/stac.js
+++ b/src/stac.js
@@ -6,7 +6,7 @@ let stacObjCounter = 0;
 // STAC Entity
 class STAC {
 
-    constructor(data, url, path, migrate = true) {
+    constructor(data, url, path, migrate = false) {
         this._id = stacObjCounter++;
         this._url = url;
         this._path = path;
@@ -141,12 +141,12 @@ class STAC {
 
     /**
      * Get the thumbnails from the assets and links in a STAC entity.
-     * 
+     *
      * @param {boolean} browserOnly - Return only images that can be shown in a browser natively (PNG/JPG/GIF/WEBP).
      * @param {?string} prefer - If not `null` (default), prefers a role over the other. Either `thumbnail` or `overview`.
-     * @returns 
+     * @returns
      */
-    getThumbnails(browserOnly = false, prefer = null) { // prefer can be either 
+    getThumbnails(browserOnly = false, prefer = null) { // prefer can be either
       let thumbnails = this.getAssetsWithRoles(['thumbnail', 'overview']);
       if (prefer && thumbnails.length > 1) {
           thumbnails.sort(a => a.roles.includes(prefer) ? -1 : 1);


### PR DESCRIPTION
By default the STAC version was migrated to 1.0.0 and all data were
    displayed as 1.0.0 instead of 0.9.0 like mentioned in our api. The
    version is displayed in the link button.