### PR TITLE
PB-1550: removed obsolete preprocessor

### DIFF
--- a/config.js
+++ b/config.js
@@ -35,17 +35,5 @@ module.exports = {
     requestHeaders: {},
     requestQueryParameters: {},
     socialSharing: ['email', 'bsky', 'mastodon', 'x'],
-    preprocessSTAC: stac => {
-        if (stac.getBrowserPath() == '/') {
-          stac.conformsTo.push('https://api.stacspec.org/v1.0.0/item-search');
-          stac.links = stac.links.map(link => {
-            if (link.rel === 'search') {
-              link.type = 'application/geo+json';
-            }
-            return link;
-          });
-        }
-        return stac;
-      },
     authConfig: null
 };


### PR DESCRIPTION
Since the API now handles the geo+json content type issue, we should remove the preprocessor from the browser's config